### PR TITLE
add iterator support

### DIFF
--- a/deferred-leveldown.js
+++ b/deferred-leveldown.js
@@ -1,10 +1,12 @@
 var util              = require('util')
   , AbstractLevelDOWN = require('abstract-leveldown').AbstractLevelDOWN
+  , AbstractIterator  = require('abstract-leveldown').AbstractIterator
 
 function DeferredLevelDOWN (location) {
   AbstractLevelDOWN.call(this, typeof location == 'string' ? location : '') // optional location, who cares?
   this._db         = undefined
   this._operations = []
+  this._iterators  = []
 }
 
 util.inherits(DeferredLevelDOWN, AbstractLevelDOWN)
@@ -14,6 +16,9 @@ DeferredLevelDOWN.prototype.setDb = function (db) {
   this._db = db
   this._operations.forEach(function (op) {
     db[op.method].apply(db, op.args)
+  })
+  this._iterators.forEach(function (it) {
+    it.setDb(db)
   })
 }
 
@@ -39,9 +44,40 @@ DeferredLevelDOWN.prototype._isBuffer = function (obj) {
   return Buffer.isBuffer(obj)
 }
 
-// don't need to implement this as LevelUP's ReadStream checks for 'ready' state
-DeferredLevelDOWN.prototype._iterator = function () {
-  throw new TypeError('not implemented')
+DeferredLevelDOWN.prototype._iterator = function (options) {
+  var it = new Iterator(options)
+  this._iterators.push(it)
+  return it
 }
 
+function Iterator (options) {
+  AbstractIterator.call(this, options)
+
+  this._options = options
+  this._iterator = null
+  this._operations = []
+}
+
+util.inherits(Iterator, AbstractIterator)
+
+Iterator.prototype.setDb = function (db) {
+  var it = this._iterator = db.iterator(this._options)
+  this._operations.forEach(function (op) {
+    it[op.method].apply(it, op.args)
+  })
+}
+
+Iterator.prototype._operation = function (method, args) {
+  if (this._iterator)
+    return this._iterator[method].apply(this._iterator, args)
+  this._operations.push({ method: method, args: args })
+}
+
+'next end'.split(' ').forEach(function (m) {
+  Iterator.prototype['_' + m] = function () {
+    this._operation(m, arguments)
+  }
+})
+
 module.exports = DeferredLevelDOWN
+

--- a/test.js
+++ b/test.js
@@ -99,3 +99,35 @@ test('many operations', function (t) {
 
   t.end()
 })
+
+test('iterators', function (t) {
+  var ld = new DeferredLevelDOWN('loc')
+  var it = ld.iterator()
+  var nextFirst = false
+
+  it.next(function (err, key, value) {
+    nextFirst = true
+    t.error(err)
+    t.equal(key, 'key')
+    t.equal(value, 'value')
+  })
+
+  it.end(function (err) {
+    t.error(err)
+    t.ok(nextFirst)
+    t.end()
+  })
+
+  ld.setDb({ iterator: function (options) {
+    return {
+        next : function (cb) {
+          cb(null, 'key', 'value')
+        }
+      , end : function (cb) {
+        process.nextTick(cb)
+      }
+    }
+  }})
+
+  t.end()
+})


### PR DESCRIPTION
Deferred-leveldown should handle all deferred situations, so levelup and it's readstream implementation don't need to care.