### PR TITLE
change api to leveldown api

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,24 @@ DeferredLevelDOWN
 
 **DeferredLevelDOWN** implements the basic [AbstractLevelDOWN](https://github.com/rvagg/node-abstract-leveldown) API so it can be used as a drop-in replacement where LevelDOWN is needed.
 
-`put()`, `get()`, `del()` and `batch()` operations are all queued and kept in memory until a new LevelDOWN-compatible object can be supplied.
-
-The `setDb(db)` method is used to supply a new LevelDOWN object. Once received, all queued operations are replayed against that object, in order.
+`put()`, `get()`, `del()` and `batch()` operations are all queued and kept in memory until the LevelDOWN-compatible object has been opened through **DeferredLevelDOWN**'s `open()` method.
 
 `batch()` operations will all be replayed as the array form. Chained-batch operations are converted before being stored.
+
+```js
+var Deferred  = require('deferred-leveldown')
+  , LevelDOWN = require('leveldown')
+
+var db = Deferred(LevelDOWN('location'))
+
+db.put('foo', 'bar', function (err) {
+
+})
+
+db.open(function (err) {
+  // ...
+})
+```
 
 Contributing
 ------------

--- a/deferred-leveldown.js
+++ b/deferred-leveldown.js
@@ -22,9 +22,11 @@ DeferredLevelDOWN.prototype._open = function (options, callback) {
     self._operations.forEach(function (op) {
       self._db[op.method].apply(self._db, op.args)
     })
+    self._operations = []
     self._iterators.forEach(function (it) {
       it.setDb(self._db)
     })
+    self._iterators = []
     open(self)
     callback()
   })


### PR DESCRIPTION
this changes the api from

```js
var db = DeferredLevelDOWN()
var down = leveldown('location')
down.open(function (err) {
  db.setDb(down)
})
```

to

```js
var db = DeferredLevelDOWN(leveldown('location'))
db.open(function (err) {})
```

This not only is simpler, but makes deferredleveldown have an api very similar to leveldown, which means in the near future we can do

```js
var db = levelup(deferred(leveldown('location')))

// or, with an already open leveldown:
var db = levelup(leveldown('location'))

// or, with the level-lazy-open module:
var db = levelup(lazyOpen(leveldown('location')))
```

Composability!

This of course is a breaking change, but necessary for levelup@2

cc @ralphtheninja @substack @mcollina @jcrugzz 