### PR TITLE
iterator after setdb

### DIFF
--- a/deferred-leveldown.js
+++ b/deferred-leveldown.js
@@ -45,6 +45,8 @@ DeferredLevelDOWN.prototype._isBuffer = function (obj) {
 }
 
 DeferredLevelDOWN.prototype._iterator = function (options) {
+  if (this._db)
+    return this._db.iterator.apply(this._db, arguments)
   var it = new DeferredIterator(options)
   this._iterators.push(it)
   return it

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "abstract-leveldown": "~2.4.0"
   },
   "devDependencies": {
-    "tape": "~1.0.4"
+    "tape": "^4.1.0"
   },
   "scripts": {
     "test": "node test.js"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "abstract-leveldown": "~2.4.0"
   },
   "devDependencies": {
-    "tape": "^4.1.0"
+    "tape": "~4.1.0"
   },
   "scripts": {
     "test": "node test.js"

--- a/test.js
+++ b/test.js
@@ -133,3 +133,33 @@ test('iterators', function (t) {
 
   t.end()
 })
+
+test('iterator after setDb', function (t) {
+  t.plan(5)
+  var ld = new DeferredLevelDOWN('loc')
+  var nextFirst = false
+
+  ld.setDb({ iterator: function (options) {
+    return {
+        next : function (cb) {
+          cb(null, 'key', 'value')
+        }
+      , end : function (cb) {
+        process.nextTick(cb)
+      }
+    }
+  }})
+  var it = ld.iterator()
+
+  it.next(function (err, key, value) {
+    nextFirst = true
+    t.error(err)
+    t.equal(key, 'key')
+    t.equal(value, 'value')
+  })
+
+  it.end(function (err) {
+    t.error(err)
+    t.ok(nextFirst)
+  })
+})

--- a/test.js
+++ b/test.js
@@ -115,7 +115,6 @@ test('iterators', function (t) {
   it.end(function (err) {
     t.error(err)
     t.ok(nextFirst)
-    t.end()
   })
 
   ld.setDb({ iterator: function (options) {


### PR DESCRIPTION
If setDb() has already been called, iterators will hang because there is no check to see if `this._db` has been set already. I also fixed a test that calls `.end()` twice, which fails on newer versions of tape.