### PR TITLE
Create iterators in order

### DIFF
--- a/deferred-leveldown.js
+++ b/deferred-leveldown.js
@@ -13,6 +13,8 @@ function DeferredLevelDOWN (db) {
 
 inherits(DeferredLevelDOWN, AbstractLevelDOWN)
 
+DeferredLevelDOWN.prototype.type = 'deferred-leveldown'
+
 DeferredLevelDOWN.prototype._open = function (options, callback) {
   var self = this
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "hallmark": "^2.0.0",
     "level-community": "^3.0.0",
     "nyc": "^14.0.0",
+    "reachdown": "^1.0.0",
     "standard": "^14.0.0",
     "tape": "^4.10.0"
   },

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 var test = require('tape')
+var reachdown = require('reachdown')
 var DeferredLevelDOWN = require('./')
 var noop = function () {}
 
@@ -521,4 +522,16 @@ test('iterator - is created in order', function (t) {
     t.error(err, 'no error')
     t.same(ld2._db.order, ['put', 'iterator created'])
   })
+})
+
+test('reachdown supports deferred-leveldown', function (t) {
+  // Define just enough methods for reachdown to see this as a real db
+  var db = { open: noop, _batch: noop, _iterator: noop }
+  var ld = new DeferredLevelDOWN(db)
+
+  t.is(ld.type, 'deferred-leveldown')
+  t.is(reachdown(ld, 'deferred-leveldown'), ld)
+  t.is(reachdown(ld), db)
+
+  t.end()
 })


### PR DESCRIPTION
This fixes the (currently disabled) `create-stream-vs-put-racecondition.js` test in `levelup` (https://github.com/Level/levelup/issues/497). That test was originally meant for `leveldown` I believe, before it had snapshots. Today, it's more relevant for `memdown`, which is secretly synchronous. E.g. it does (simplified):

```js
memdown.prototype.put = function (.., callback) {
  this.store.put(..)
  process.nextTick(callback)
}
```

Rather than:

```js
memdown.prototype.put = function (.., callback) {
  process.nextTick(function () {
    this.store.put(..)
    callback()
  })
}
```

Before this PR, if you did the following on a deferred db:

```js
db.iterator()
db.put(..)
```

Then on the underlying db it would actually be executed as if you did:

```js
db.put(..)
db.iterator()
```

Which in the case of `memdown`, because it is synchronous, means the put was written before the iterator (snapshot) is created. Does it matter? Probably not a whole lot, but I think this PR makes for a less surprising behavior.